### PR TITLE
Fix inline js not working

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -17,7 +17,7 @@ window.addEventListener("click", function(e) {
     const target = clickedLink(e.target);
     const href = target && target.href && target.href.trim();
     const hrefAttr = target && target.getAttribute("href");
-    const shouldHandleClick = href && hrefAttr && !href.startsWith("javascript:") && hrefAttr !== "#";
+    const shouldHandleClick = href && hrefAttr && !hrefAttr.startsWith("javascript:") && hrefAttr !== "#";
     
     if (shouldHandleClick) {
       e.preventDefault();


### PR DESCRIPTION
if href starts with `javascript:` `shouldHandleClick` may still be set to true because `href` being boolean never starts with `javascript:`