### PR TITLE
Enable content script execution in iframes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content-script.js"]
+      "js": ["content-script.js"],
+      "all_frames": true
     }
   ],
   "options_ui": {


### PR DESCRIPTION
Some websites like [threejs](https://threejs.org/manual/#en/prerequisites) wrap their content in iframes and hyperlinks in these iframes were not being fixed. Try to open any link on that page with CMD+click.

This commit makes our content script apply to all frames by simply adding `"all_frames": true` to the manifest. Tested on Chrome and Firefox.